### PR TITLE
Fixed issue with long passwords in altmgr

### DIFF
--- a/src/main/java/net/wurstclient/altmanager/screens/AltEditorScreen.java
+++ b/src/main/java/net/wurstclient/altmanager/screens/AltEditorScreen.java
@@ -83,6 +83,7 @@ public abstract class AltEditorScreen extends Screen
 				stars += "*";
 			return stars;
 		});
+		passwordBox.setMaxLength(64);
 		children.add(passwordBox);
 		
 		setInitialFocus(emailBox);


### PR DESCRIPTION
My minecraft account has a very long password and I was unable to add it to your client, I had already fixed this in another fork but I figured I'd make a PR for you.

The password field now supports passwords up to 64 chars in length.